### PR TITLE
Added support for Nested attributes in MongoBD

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To use the Moped authenticator, configure it in your cas.yml:
           pepper: "suffix of the password" # optional
           extra_attributes:
             email: "email_database_column"
-            fullname: "displayname_database_column"
+            fullname: "user_info.full_name"
 
 ## Contributing to casino-moped_authenticator
 

--- a/casino-moped_authenticator.gemspec
+++ b/casino-moped_authenticator.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'moped', '~> 1.5'
   s.add_runtime_dependency 'unix-crypt', '~> 1.1'
   s.add_runtime_dependency 'bcrypt', '~> 3.0'
-  s.add_runtime_dependency 'casino', '~> 2.0'
+  s.add_runtime_dependency 'casino', '~> 3.0'
   s.add_runtime_dependency 'phpass-ruby', '~> 0.1'
 end

--- a/lib/casino/moped_authenticator.rb
+++ b/lib/casino/moped_authenticator.rb
@@ -45,7 +45,7 @@ class CASino::MopedAuthenticator
     return false if password_from_database.to_s.strip == ''
 
     # SHA256 password if enabled
-    password = Digest::SHA256.digest(password) if @options[:additional_digest] && @options[:additional_digest] == 'sha256'
+    password = Digest::SHA256.hexdigest(password) if @options[:additional_digest] && @options[:additional_digest] == 'sha256'
 
     magic = password_from_database.split('$')[1]
     case magic

--- a/lib/casino/moped_authenticator.rb
+++ b/lib/casino/moped_authenticator.rb
@@ -4,7 +4,6 @@ require 'bcrypt'
 require 'phpass'
 
 class CASino::MopedAuthenticator
-
   # @param [Hash] options
   def initialize(options)
     @options = options
@@ -30,11 +29,11 @@ class CASino::MopedAuthenticator
   def get_nested(item, key_string, first = false)
     return_item = item.dup
 
-    return return_item unless item.kind_of?(Hash)
+    return return_item unless item.is_a?(Hash)
 
     key_string.split('.').each do |key_part|
       result = return_item[key_part]
-      result = result[0] if result.kind_of?(Array) && first
+      result = result[0] if result.is_a?(Array) && first
       return_item = result
     end
 
@@ -68,7 +67,7 @@ class CASino::MopedAuthenticator
   end
 
   def valid_password_with_phpass?(password, password_from_database)
-    Phpass.new().check(password, password_from_database)
+    Phpass.new.check(password, password_from_database)
   end
 
   def extra_attributes(user)

--- a/lib/casino/moped_authenticator.rb
+++ b/lib/casino/moped_authenticator.rb
@@ -43,6 +43,10 @@ class CASino::MopedAuthenticator
 
   def valid_password?(password, password_from_database)
     return false if password_from_database.to_s.strip == ''
+
+    # SHA256 password if enabled
+    password = Digest::SHA256.digest(password) if @options[:additional_digest] && @options[:additional_digest] == 'sha256'
+
     magic = password_from_database.split('$')[1]
     case magic
     when /\A2a?\z/

--- a/spec/casino_core/nested_attributes_spec.rb
+++ b/spec/casino_core/nested_attributes_spec.rb
@@ -1,0 +1,92 @@
+require 'spec_helper'
+require 'casino/moped_authenticator'
+require 'digest'
+require 'bcrypt'
+
+describe 'Nested Attributes' do
+
+  let(:options) do
+    {
+      database_url: 'mongodb://localhost:27017/my_nested_db?safe=true',
+      collection: 'users',
+      username_column: 'emails.address',
+      password_column: 'services.password.bcrypt',
+      additional_digest: 'sha256',
+      extra_attributes: { roles: 'roles' }
+    }
+  end
+
+  let(:password) {  'testpassword' }
+  let(:bcrypted_password) { BCrypt::Password.create(Digest::SHA256.hexdigest(password)) } # This is standard in Node Bcrypt
+  let(:email_address) {  'test@example.com' }
+  let(:roles) { %w(admin user) }
+
+  subject { CASino::MopedAuthenticator.new(options) }
+
+  before do
+    create_user(email_address, bcrypted_password, roles: roles)
+  end
+  after { @session.drop }
+
+  describe '#validate' do
+
+    context 'valid username' do
+      context 'valid password' do
+        it 'returns the username' do
+          subject.validate(email_address, password)[:username].should eq(email_address)
+        end
+
+        it 'returns the extra attributes' do
+          subject.validate(email_address, password)[:extra_attributes][:roles].should eq(roles)
+        end
+      end
+
+      context 'invalid password' do
+        it 'returns false' do
+          subject.validate(email_address, 'wrong').should eq(false)
+        end
+      end
+
+      context 'NULL password field' do
+        it 'returns false' do
+          update_user_pw 'test', nil
+
+          subject.validate(email_address, 'wrong').should eq(false)
+        end
+      end
+
+      context 'empty password field' do
+        it 'returns false' do
+          update_user_pw 'test', ''
+
+          subject.validate(email_address, 'wrong').should eq(false)
+        end
+      end
+    end
+
+    context 'invalid username' do
+      it 'returns false' do
+        subject.validate('wrong@example.com', password).should eq(false)
+      end
+    end
+  end
+
+  def create_user(email_address, bcrypted_password, extra = {})
+    session[options[:collection]].insert({
+      emails: [{ address: email_address }],
+      services: { password: { bcrypt: bcrypted_password } }
+    }.merge(extra))
+  end
+
+  def update_user_pw(username, new_password)
+    session[options[:collection]].find(username: username).update(password: new_password)
+  end
+
+  def user_with_name(username)
+    session[options[:collection]].find(username: username).first
+  end
+
+  def session
+    @session ||= ::Moped::Session.connect(options[:database_url])
+  end
+end


### PR DESCRIPTION
So things like password_column: "services.password.bcrypt" now work. This is essential when you are using it in combination with Meteor.

Also bumped Casino version requirement from 2 to 3.
