### PR TITLE
Update casino gem dependency to allow v3 and v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,5 @@ rvm:
   - 2.0.0
 services:
   - mongodb
+before_install:
+  - gem install bundler

--- a/casino-moped_authenticator.gemspec
+++ b/casino-moped_authenticator.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'moped', '~> 1.5'
   s.add_runtime_dependency 'unix-crypt', '~> 1.1'
   s.add_runtime_dependency 'bcrypt', '~> 3.0'
-  s.add_runtime_dependency 'casino', '~> 3.0'
+  s.add_runtime_dependency 'casino', ['>= 3.0', '< 5.0']
   s.add_runtime_dependency 'phpass-ruby', '~> 0.1'
 end


### PR DESCRIPTION
Tried this out with CASino 4.0.2. Worked fine.
